### PR TITLE
break: rework session handling

### DIFF
--- a/.editor/.gitignore
+++ b/.editor/.gitignore
@@ -1,1 +1,0 @@
-neovim-session.vim

--- a/README.md
+++ b/README.md
@@ -45,13 +45,21 @@ Via [lazy.nvim](https://github.com/folke/lazy.nvim):
 ## Configuration
 
 ```lua
-{ 'mistweaverco/kikao.nvim',
+{
+  'mistweaverco/kikao.nvim',
   opts = {
     -- Checks for the existence of the project root by checking for these directories
-    project_dir_matchers = { ".editor" },
+    -- If none are found, the session won't be loaded or saved
+    project_dir_matchers = { ".git", ".svn", ".jj", ".hg" },
     -- The path to the session file
-    -- If not provided, the session file will be stored in {{PROJECT_DIR}}/.editor/neovim-session.vim
+    -- If not provided, the session file will be stored in:
+    -- ~/.cache/nvim/kikao.nvim/{{SHA256_PROJECT_DIR}}/session.vim
+    --
+    -- If you want to store the session file in the project root,
+    -- you can set this to "{{PROJECT_DIR}}/.session.vim"
     session_file_path = nil,
+    -- The name of the session file
+    session_file_name = "session.vim",
     -- Don't start or restore a session if the file is in the deny_on_path list
     -- and you opened that file directly
     deny_on_path = {
@@ -61,17 +69,25 @@ Via [lazy.nvim](https://github.com/folke/lazy.nvim):
 },
 ```
 
-Create a `.editor` directory in your project root and
-add the following to your `.gitignore` file:
-
-```
-.editor/neovim-session.vim
-```
-
 ## How
 
 How does it work?
 
-- When you open neovim, kikao will check if there is a session file in the project root.
-- If there is a session file, it will be loaded.
+- When you open neovim, kikao will for an existing session file for the project.
+- If there is a session file, it'll be loaded.
 - When you close neovim, kikao will save the session file in the project root.
+
+Sessions are stored in a directory structure based on the SHA256 hash of the
+project root path.
+
+For example:
+
+```
+~/.cache/nvim/kikao.nvim/3a7bd3c8e5f6f7e8f9e0d1c2b3a4b5c6d7e8f9a0b1c2d3e4f5g6h7i8j9k0l1m2/session.vim
+```
+
+Additionally, kikao saves metadata about the session in a separate file called
+`metadata.json` in the same directory as the session file.
+
+This metadata includes:
+- The project root path as (`project_dir`)

--- a/lua/kikao/config/init.lua
+++ b/lua/kikao/config/init.lua
@@ -2,8 +2,9 @@ local AuCommands = require("kikao.config.aucommands")
 local M = {}
 
 M.defaults = {
-  project_dir_matchers = { ".editor" },
+  project_dir_matchers = { ".git", ".svn", ".jj", ".hg" },
   session_file_path = nil,
+  session_file_name = "session.vim",
   deny_on_path = {
     ".git/COMMIT_EDITMSG",
   },
@@ -12,6 +13,7 @@ M.defaults = {
 M.options = M.defaults
 
 M.setup = function(config)
+  config = config or {}
   M.options = vim.tbl_deep_extend("force", M.defaults, config or {})
   AuCommands.setup(M.options)
 end

--- a/lua/kikao/config/utils.lua
+++ b/lua/kikao/config/utils.lua
@@ -1,0 +1,104 @@
+local M = {}
+local IS_WINDOWS = vim.loop.os_uname().version:match("Windows")
+
+M.join_paths = function(...)
+  local paths = { ... }
+  return table.concat(paths, IS_WINDOWS and "\\" or "/")
+end
+
+-- get kikao cache dir
+--- @param path string|nil optional path to append as hash subdir
+--- @return string|nil
+--- @usage local cache_dir = utils.get_cache_dir()
+M.get_cache_dir = function(path)
+  local cache = vim.fn.stdpath("cache")
+  if path then
+    local hash = vim.fn.sha256(path)
+    return M.join_paths(cache, "kikao.nvim", hash)
+  end
+  return M.join_paths(cache, "kikao.nvim")
+end
+
+-- find nearest file in parent directories, starting from the current buffer file path
+--- @param name string|table file or list of files to search for
+--- @param type string|nil 'file'|'directory' ( defaults to 'file' )
+--- @return string|nil
+--- @usage local p = utils.find_first_in_parent_dirs('.git', 'directory')
+M.find_first_in_parent_dirs = function(name, type)
+  type = type or "file"
+  return vim.fs.find(name, {
+    type = type,
+    upward = true,
+    limit = 1,
+    path = M.get_current_buffer_dir(),
+  })[1]
+end
+
+M.get_current_buffer_dir = function()
+  local buf_path = vim.api.nvim_buf_get_name(0)
+  if buf_path == "" then
+    return vim.loop.cwd()
+  else
+    return vim.fs.dirname(buf_path)
+  end
+end
+
+M.file_exists = function(path)
+  return vim.loop.fs_stat(path) ~= nil
+end
+
+M.write_project_metadata = function(project_root, metadata)
+  local metadata_file_path = M.join_paths(M.get_cache_dir(project_root), "metadata.json")
+  local new_metadata
+  local filehandle = io.open(metadata_file_path, "r+")
+  if M.file_exists(metadata_file_path) then
+    if not filehandle then
+      return
+    end
+    local content = filehandle:read("*a")
+    local old_metadata = vim.fn.json_decode(content) or {}
+    new_metadata = vim.tbl_extend("force", old_metadata, metadata)
+  else
+    new_metadata = metadata
+  end
+  if not filehandle then
+    return
+  end
+  filehandle:write(vim.fn.json_encode(new_metadata))
+  filehandle:close()
+end
+
+M.get_nearest_vcs_root = function()
+  return M.find_first_in_parent_dirs({ ".git", ".hg", ".jj" }, "directory")
+end
+
+---@class SessionSavePathInfo
+---@field session_file_path string full path to session file
+---@field project_root string project root directory
+
+---Get session save path
+---@param markers table|nil optional list of project dir markers
+---@return SessionSavePathInfo|nil
+M.get_session_save_path_info = function(markers)
+  local root_dir
+  if markers ~= nil then
+    root_dir = M.find_first_in_parent_dirs(markers, "directory")
+  else
+    root_dir = M.get_nearest_vcs_root()
+  end
+  if root_dir == nil then
+    return nil
+  end
+  local session_dir = M.get_cache_dir(root_dir)
+  if session_dir == nil then
+    return nil
+  end
+  vim.fn.mkdir(session_dir, "p")
+  local session_file_path = session_dir
+  return {
+    session_file_path = session_file_path,
+    project_root = root_dir,
+  }
+end
+
+return M


### PR DESCRIPTION
THIS IS A BREAKING CHANGE!!!

Sessions are now stored in the cache dir of your OS.

The sessions are stored in their own directory that is the SHA256 checksum of the absolute project_root dir.

Additonally metadata.json is also stored in the session dir.

The metadata.json contains only the project_dir for now.

This makes it easier to get the plugin up and running without messing around with repository directory structures.

Also you don't need to add the .editor/ directory to the vsc ignore anymore.