### PR TITLE
feat(api): add `clear` and `clear_all` functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,11 @@ Additionally, kikao saves metadata about the session in a separate file called
 
 This metadata includes:
 - The project root path as (`project_dir`)
+
+## API
+
+- `require("kikao").clear()` - Clears the current project's session file.
+  Also closes all buffers.
+- `require("kikao").clear_all()` - Clears all session files.
+  Also closes all buffers.
+- `require("kikao").version()` - Returns the version info.

--- a/lua/kikao/api.lua
+++ b/lua/kikao/api.lua
@@ -1,0 +1,33 @@
+local M = {}
+local Config = require("kikao.config")
+
+M.setup = function(config)
+  Config.setup(config)
+end
+
+---Clears cached data for the current project and closes all Kikao buffers.
+M.clear = function()
+  local utils = require("lua.kikao.config.utils")
+  local project_root = utils.get_root_dir(Config.options.project_dir_matchers)
+  local project_cache_dir = utils.get_cache_dir(project_root)
+  if project_cache_dir and utils.file_exists(project_cache_dir) then
+    vim.fn.delete(project_cache_dir, "rf")
+  end
+  for _, buf in pairs(vim.fn.getbufinfo()) do
+    vim.api.nvim_buf_delete(buf.bufnr, { force = true })
+  end
+end
+
+---Clears all cached data and closes all Kikao buffers.
+M.clear_all = function()
+  local utils = require("lua.kikao.config.utils")
+  local all_cache_dir = utils.get_cache_dir()
+  if all_cache_dir and utils.file_exists(all_cache_dir) then
+    vim.fn.delete(all_cache_dir, "rf")
+  end
+  for _, buf in pairs(vim.fn.getbufinfo()) do
+    vim.api.nvim_buf_delete(buf.bufnr, { force = true })
+  end
+end
+
+return M

--- a/lua/kikao/config/utils.lua
+++ b/lua/kikao/config/utils.lua
@@ -108,6 +108,23 @@ M.write_project_metadata = function(project_root, metadata)
   M.write_file(metadata_file_path, vim.json.encode(new_metadata))
 end
 
+---Check if current buffers are empty,
+---not counting unlisted buffers,
+---or only the start buffer is open
+---@return boolean
+M.is_empty_or_start_buffer = function()
+  local buf_info = vim.fn.getbufinfo({ buflisted = 1 })
+  if #buf_info == 0 then
+    return true
+  elseif #buf_info == 1 then
+    local buf = buf_info[1]
+    if vim.fn.getbufline(buf.bufnr, 1)[1] == "" then
+      return true
+    end
+  end
+  return false
+end
+
 ---Write content to a file
 ---@param file_path string full path to the file
 ---@param content string content to write

--- a/lua/kikao/globals/init.lua
+++ b/lua/kikao/globals/init.lua
@@ -1,5 +1,5 @@
 local M = {}
 
-M.VERSION = "3.0.2"
+M.VERSION = "3.1.0"
 
 return M

--- a/lua/kikao/init.lua
+++ b/lua/kikao/init.lua
@@ -1,12 +1,24 @@
 local Globals = require("kikao.globals")
-local Config = require("kikao.config")
 local Logger = require("kikao.logger")
+local Api = require("kikao.api")
 local M = {}
 
+---Sets up Kikao with the provided configuration.
 M.setup = function(config)
-  Config.setup(config)
+  Api.setup(config)
 end
 
+---Clears cached data for the current project and closes all Kikao buffers.
+M.clear = function()
+  Api.clear()
+end
+
+---Clears all cached data and closes all Kikao buffers.
+M.clear_all = function()
+  Api.clear_all()
+end
+
+---Prints the current Kikao version and Neovim version to the log.
 M.version = function()
   local neovim_version = vim.fn.execute("version") or "Unknown"
   Logger.info("Kikao version: " .. Globals.VERSION .. "\n\n" .. "Neovim version: " .. neovim_version)


### PR DESCRIPTION
- `require("kikao").clear()` - Clears the current project's session file. Also closes all buffers.
- `require("kikao").clear_all()` - Clears all session files. Also closes all buffers.
- `require("kikao").version()` - Returns the version info.

Also fix an issue where the the session kept the last opened file info, instead of just wiping all session data, when you have no buffers left.