### PR TITLE
fix(session): load conflicting with nvim start cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See: [lazy.nvim](https://github.com/folke/lazy.nvim)
 ```lua
 {
   'mistweaverco/kikao.nvim',
-  version = 'v3.3.0',
+  version = 'v3.3.1',
   opts = {}
 },
 ```
@@ -68,7 +68,7 @@ See: [packer.nvim](https://github.com/wbthomason/packer.nvim)
 ```lua
 use {
   'mistweaverco/kikao.nvim',
-  tag = 'v3.3.0',
+  tag = 'v3.3.1',
   config = function()
     require('snap').setup({})
   end
@@ -84,7 +84,7 @@ use {
 ```lua
 vim.pack.add({
   src = 'https://github.com/mistweaverco/kikao.nvim.git',
-  version = 'v3.3.0',
+  version = 'v3.3.1',
 })
 require('snap').setup({})
 ```

--- a/lua/kikao/config/aucommands.lua
+++ b/lua/kikao/config/aucommands.lua
@@ -41,12 +41,19 @@ local vim_enter_cb = function(config, data, session_file_path)
     -- Check if the session file is not empty
     local session_file_size = vim.fn.getfsize(session_file)
     if session_file_size > 0 then
+      -- Store the current working directory before sourcing the session
+      -- Session files can change the cwd, so we need to restore it afterward
+      local original_cwd = vim.fn.getcwd()
+
       -- Try to source the session file safely
       local ok, err = pcall(function()
         vim.cmd("silent! source " .. session_file)
       end)
       if not ok then
         vim.notify("Failed to restore session: " .. err, vim.log.levels.WARN)
+      else
+        -- Restore the original working directory after sourcing the session
+        vim.cmd("cd " .. vim.fn.fnameescape(original_cwd))
       end
 
       if data.file then


### PR DESCRIPTION
Let's say I have a git project in ~/projects/personal/foo.

This project contains a direct child-folder bar.

If I change to ~/projects/personal/foo/bar and open neovim the root cwd for neovim is the folder foo, which is an expected behaviour.

Now I open some files and quit neovim. Kikao persists them via session.nvim in the kikao.nvim project cache folder.

If I know enter ~/projects/personal/foo and open neovim, the cwd changes due to sourcing the session, but this is wrong. We want to keep the current cwd.

Before sourcing, we store the current cwd,
then try to restore the session and then change back the cwd.